### PR TITLE
Shortening and organizing the title filter into it's own module

### DIFF
--- a/titlefilter.py
+++ b/titlefilter.py
@@ -1,0 +1,20 @@
+title_filter = [
+    "(",
+    ")",
+    "YouTube",
+    "Waterfox",
+    "Audio",
+    "Official Music Video",
+    "Official Audio",
+    "WSHH Exclusive",
+    "- ",
+    "-",
+    "Official",
+    " ",
+    "  ",
+    "   ",
+    "Google Chrome",
+    "Firefox",
+    "Internet Explorer"
+]
+

--- a/windows.py
+++ b/windows.py
@@ -1,6 +1,7 @@
 import ctypes
 from pypresence import Presence
 import time, os, sys
+from titlefilter import title_filter
 
 def full():
     EnumWindows = ctypes.windll.user32.EnumWindows
@@ -20,31 +21,17 @@ def full():
     sub = 'YouTube'
     for text in titles:
         if sub in text:
-            textp = text.replace("(", "")
-            textp2 = textp.replace(")", "")
-            textp3 = textp2.replace("YouTube", "")
-            textp4 = textp3.replace("Waterfox", "")
-            textp5 = textp4.replace("Audio", "")
-            textp6 = textp5.replace("Official Music Video", "")
-            textp7 = textp6.replace("Official Audio", "")
-            textp8 = textp7.replace("WSHH Exclusive", "")
-            textp9 = textp8.replace("- ", "")
-            textp10 = textp9.replace("-", "")
-            textp11 = textp10.replace("Official", "")
-            textp12 = textp11.replace("  ", "")
-            textp13 = textp12.replace("   ", "")
-            textp14 = textp13.replace("    ", "")
-            textp15 = textp14.replace("Google Chrome", "")
-            textp16 = textp15.replace("Firefox", "")
-            textp17 = textp16.replace("Internet Explorer", "")
+            for title in title_filter:
+                textp = text.replace(title, "")
 
     client_id = ''  # Fake ID, put your real one here
     RPC = Presence(client_id)  # Initialize the client class
     RPC.connect() # Start the handshake loop
-    print(RPC.update(state=textp17 + " on Youtube", details="Listening to: "))  # Set the presence
+    print(RPC.update(state=textp + " on Youtube", details="Listening to: "))  # Set the presence
     while True:  # The presence will stay on as long as the program is running
         time.sleep(15) # Can only update rich presence every 15 seconds
         RPC.close()
         full()
 
 full()
+


### PR DESCRIPTION
I haven't checked if this works nor do I know if you're accepting suggestions/PR's, but something like this should be considered, it looks nicer and I bet it'll be easier for you to manage in case you need to add more of these filters.

I've moved all the filters into a file which contains them as a list, and I iterate in the main file (windows.py) through each title and replace them accordingly, you should check if this works - I would, but I'm on Linux.

Alternatively, close this PR if you'd rather not accept suggestions, or edit my  commits before accepting. Cheers and interesting project!